### PR TITLE
feat: add seeder for admin user

### DIFF
--- a/src/configurations/boot.cpp
+++ b/src/configurations/boot.cpp
@@ -7,6 +7,7 @@
 #include <glog/logging.h>
 #include <drogon/drogon.h>
 #include "../migrations/migration.hpp"
+#include "../misc/seeder.hpp"
 
 Json::Value config;
 
@@ -30,11 +31,11 @@ namespace configuration
         try {
             using namespace drogon;
             const auto addr = config["addr"].asString();
-            const auto port = config["port"].asInt();//std::atoi(config["port"].asString().c_str());
+            const auto port = config["port"].asInt();
             LOG(INFO) << "access api at http://" << addr << ":" << port;
             app()
                 .addListener(addr, port)
-                // .enableSession(300) // 5 minutes
+                .enableSession(300) // 5 minutes
                 .run();
         } catch (const std::exception& e) {
             LOG(FATAL) << e.what();
@@ -48,6 +49,7 @@ namespace configuration
         setup_directories(config["directories"]);
 
         migration::migrate(config["migrations"]);
+        misc::seeder(config["admin"]);
 
         LOG(INFO) << "starting api";
 

--- a/src/misc/seeder.cpp
+++ b/src/misc/seeder.cpp
@@ -1,0 +1,17 @@
+#include "seeder.hpp"
+#include "../service/user.hpp"
+#include "../models/user.hpp"
+#include "../models/model.hpp"
+
+void misc::seeder(const Json::Value &config) 
+{
+    static auto storage = model::get_storage();
+    static auto service = service::user(storage);
+    auto admin = model::user::from_json(config["admin"]);
+
+    if (service.create(admin) != -1) {
+        LOG(INFO) << "User Admin was created successfuly";
+        return;
+    }
+    LOG(WARNING) << "User Admin was not created";
+}

--- a/src/misc/seeder.hpp
+++ b/src/misc/seeder.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "json/value.h"
+
+namespace misc 
+{
+    void seeder(const Json::Value& config);
+}


### PR DESCRIPTION
What was done: Added a seeder that creates a default administrator user.

Why: To ensure the system always has an initial admin.